### PR TITLE
Protractor tests are now parseable, there is a try catch during the xml parsing, if no report  path is specified IT SHOULD NOT EXPLODE

### DIFF
--- a/TRX_Merger/Program.cs
+++ b/TRX_Merger/Program.cs
@@ -15,7 +15,7 @@ namespace TRX_Merger
         public static int Main(string[] args)
         {
 
-            args = new string[2] { "/trx:Threewaycall.trx,Twowaycallonauto.aa.trx", "/output:res.trx" };
+            //args = new string[2] { "/trx:Threewaycall.trx,Twowaycallonauto.aa.trx", "/output:res.trx" };
 
 
             if (args.Length == 0

--- a/TRX_Merger/Program.cs
+++ b/TRX_Merger/Program.cs
@@ -14,9 +14,11 @@ namespace TRX_Merger
     {
         public static int Main(string[] args)
         {
-            
 
-            if(args.Length == 0
+            args = new string[2] { "/trx:Threewaycall.trx,Twowaycallonauto.aa.trx", "/output:res.trx" };
+
+
+            if (args.Length == 0
                 || args.Contains("/h")
                 || args.Contains("/help"))
             {
@@ -24,7 +26,7 @@ namespace TRX_Merger
                 return 1;
             }
 
-            if(args.Where(a => a.StartsWith("/trx")).FirstOrDefault() == null)
+            if (args.Where(a => a.StartsWith("/trx")).FirstOrDefault() == null)
             {
                 Console.WriteLine("/trx parameter is required");
                 return 1;
@@ -36,15 +38,15 @@ namespace TRX_Merger
             {
                 Console.WriteLine("No trx files found!");
                 return 1;
-            } 
+            }
 
-            if(trxFiles.Count == 1)
+            if (trxFiles.Count == 1)
             {
                 if (trxFiles[0].StartsWith("Error: "))
                 {
                     Console.WriteLine(trxFiles[0]);
                     return 1;
-                }                    
+                }
 
                 if (args.Where(a => a.StartsWith("/report")).FirstOrDefault() == null)
                 {
@@ -77,7 +79,7 @@ namespace TRX_Merger
 
                     Console.WriteLine("Error: " + ex.Message);
                     return 1;
-                } 
+                }
             }
             else
             {
@@ -86,7 +88,7 @@ namespace TRX_Merger
                     Console.WriteLine("/output parameter is required, when there are multiple trx files in /trx argument");
                     return 1;
                 }
-                 
+
                 string outputParam = ResolveOutputFileName(args.Where(a => a.StartsWith("/output")).FirstOrDefault());
                 if (outputParam.StartsWith("Error: "))
                 {
@@ -94,13 +96,17 @@ namespace TRX_Merger
                     return 1;
                 }
 
-                if (trxFiles.Contains(outputParam)) 
+                if (trxFiles.Contains(outputParam))
                     trxFiles.Remove(outputParam);
-                  
+
                 try
                 {
                     var combinedTestRun = TestRunMerger.MergeTRXsAndSave(trxFiles, outputParam);
-
+                    if (args.Where(a => a.StartsWith("/report")) == null)
+                    {
+                        Console.WriteLine("Report path not specified :(");
+                        return 0;
+                    }
                     string reportOutput = ResolveReportLocation(args.Where(a => a.StartsWith("/report")).FirstOrDefault());
                     if (reportOutput == null)
                         return 0;
@@ -122,7 +128,7 @@ namespace TRX_Merger
 
                     Console.WriteLine("Error: " + ex.Message);
                     return 1;
-                }           
+                }
             }
 
             return 0;
@@ -166,14 +172,14 @@ PARAMETERS:
         }
 
         private static string ResolveOutputFileName(string outputParam)
-        { 
+        {
             var splitOutput = outputParam.Split(new char[] { ':' });
 
             if (splitOutput.Length == 1
                 || !outputParam.EndsWith(".trx"))
                 return "Error: /output parameter is in the correct format. Expected /output:<file name | directory and file name>. Execute /help for more information";
 
-            return outputParam.Substring(8, outputParam.Length - 8); 
+            return outputParam.Substring(8, outputParam.Length - 8);
         }
 
         private static string ResolveReportLocation(string reportParam)
@@ -209,20 +215,20 @@ PARAMETERS:
             List<string> paths = new List<string>();
 
             var splitTrx = trxParams.Split(new char[] { ':' });
-             
+
             var searchOpts = recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
 
             if (splitTrx.Length == 1)
                 return Directory.GetFiles(Directory.GetCurrentDirectory(), "*.trx", searchOpts).ToList();
 
-            var args = trxParams.Substring(5,trxParams.Length - 5).Split(new char[] { ',' }).ToList(); 
+            var args = trxParams.Substring(5, trxParams.Length - 5).Split(new char[] { ',' }).ToList();
 
             foreach (var a in args)
             {
                 bool isTrxFile = File.Exists(a) && a.EndsWith(".trx");
                 bool isDir = Directory.Exists(a);
-                    
-                if(!isTrxFile && !isDir)
+
+                if (!isTrxFile && !isDir)
                     return new List<string>
                     {
                         string.Format("Error: {0} is not a trx file or directory", a)
@@ -233,7 +239,7 @@ PARAMETERS:
 
                 if (isDir)
                     paths.AddRange(Directory.GetFiles(a, "*.trx", searchOpts).ToList());
-                 
+
             }
 
             return paths;

--- a/TRX_Merger/TRX_Merger.csproj
+++ b/TRX_Merger/TRX_Merger.csproj
@@ -38,6 +38,10 @@
       <HintPath>..\packages\Microsoft.AspNet.Razor.4.0.0-beta6\lib\net45\Microsoft.AspNet.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="RazorEngine">
       <HintPath>..\packages\RazorEngine.4.2.2-beta1\lib\net45\RazorEngine.dll</HintPath>
     </Reference>
@@ -47,9 +51,23 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.40804.0\lib\net40\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/TRX_Merger/Utilities/TRXSerializationUtils.cs
+++ b/TRX_Merger/Utilities/TRXSerializationUtils.cs
@@ -13,105 +13,118 @@ namespace TRX_Merger.Utilities
     {
         private static string ns = "{http://microsoft.com/schemas/VisualStudio/TeamTest/2010}";
 
+
         #region Serializers
         internal static string SerializeAndSaveTestRun(TestRun testRun, string targetPath)
         {
-            XNamespace xmlns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
-            XDocument doc =
-                new XDocument(
-                  new XElement("TestRun",
-                        new XAttribute("id", testRun.Id),
-                        new XAttribute("name", testRun.Name),
-                        new XAttribute("runUser", testRun.RunUser),
-                        new XElement("Times",
-                            new XAttribute("creation", testRun.Times.Creation),
-                            new XAttribute("queuing", testRun.Times.Queuing),
-                            new XAttribute("start", testRun.Times.Start),
-                            new XAttribute("finish", testRun.Times.Finish)),
-                        new XElement("Results",
-                            testRun.Results.Select(
-                                utr =>
-                                    new XElement("UnitTestResult",
-                                        new XAttribute("computerName", utr.ComputerName),
-                                        new XAttribute("duration", utr.Duration),
-                                        new XAttribute("endTime", utr.EndTime),
-                                        new XAttribute("executionId", utr.ExecutionId),
-                                        new XAttribute("outcome", utr.Outcome),
-                                        new XAttribute("startTime", utr.StartTime),
-                                        new XAttribute("testId", utr.TestId),
-                                        new XAttribute("testListId", utr.TestListId),
-                                        new XAttribute("testName", utr.TestName),
-                                        new XAttribute("testType", utr.TestType),
-                                        new XElement("Output",
-                                             utr.Output.StdOut == null ? null : new XElement("StdOut", utr.Output.StdOut),
-                                             utr.Output.ErrorInfo == null ? null :
-                                             new XElement("ErrorInfo",
-                                                  utr.Output.ErrorInfo.Message == null ? null : new XElement("Message", utr.Output.ErrorInfo.Message),
-                                                  utr.Output.ErrorInfo.StackTrace == null ? null : new XElement("StackTrace", utr.Output.ErrorInfo.StackTrace)
-                                                  ))))),
-                      new XElement("TestDefinitions",
-                           testRun.TestDefinitions.Select(
-                                td => new XElement("UnitTest",
-                                         new XAttribute("id", td.Id),
-                                         new XAttribute("name", td.Name),
-                                         new XAttribute("storage", td.Storage),
-                                         new XElement("Execution",
-                                            new XAttribute("id", td.Execution.Id)),
-                                         new XElement("TestMethod",
-                                            new XAttribute("adapterTypeName", td.TestMethod.AdapterTypeName),
-                                            new XAttribute("className", td.TestMethod.ClassName),
-                                            new XAttribute("codeBase", td.TestMethod.CodeBase),
-                                            new XAttribute("name", td.TestMethod.Name))))),
-                        new XElement("TestEntries",
-                             testRun.TestEntries.Select(
-                                te => new XElement("TestEntry",
-                                          new XAttribute("testId", te.TestId),
-                                          new XAttribute("executionId", te.ExecutionId),
-                                          new XAttribute("testListId", te.TestListId)))),
-                        new XElement("TestLists",
-                            testRun.TestLists.Distinct().Select(
-                                 tl => new XElement("TestList",
-                                     new XAttribute("name", tl.Name),
-                                     new XAttribute("id", tl.Id)))),
-                        new XElement("ResultSummary",
-                            new XAttribute("outcome", testRun.ResultSummary.Outcome),
-                            new XElement("Counters",
-                                new XAttribute("aborted", testRun.ResultSummary.Counters.Aborted),
-                                new XAttribute("completed", testRun.ResultSummary.Counters.Completed),
-                                new XAttribute("disconnected", testRun.ResultSummary.Counters.Disconnected),
-                                new XAttribute("executed", testRun.ResultSummary.Counters.Еxecuted),
-                                new XAttribute("failed", testRun.ResultSummary.Counters.Failed),
-                                new XAttribute("inconclusive", testRun.ResultSummary.Counters.Inconclusive),
-                                new XAttribute("inProgress", testRun.ResultSummary.Counters.InProgress),
-                                new XAttribute("notExecuted", testRun.ResultSummary.Counters.NotExecuted),
-                                new XAttribute("notRunnable", testRun.ResultSummary.Counters.NotRunnable),
-                                new XAttribute("passed", testRun.ResultSummary.Counters.Passed),
-                                new XAttribute("passedButRunAborted", testRun.ResultSummary.Counters.PassedButRunAborted),
-                                new XAttribute("pending", testRun.ResultSummary.Counters.Pending),
-                                new XAttribute("timeout", testRun.ResultSummary.Counters.Timeout),
-                                new XAttribute("total", testRun.ResultSummary.Counters.Total),
-                                new XAttribute("warning", testRun.ResultSummary.Counters.Warning)),
-                            new XElement("RunInfos",
-                                testRun.ResultSummary.RunInfos.Select(
-                                    ri => new XElement("RunInfo",
-                                        new XAttribute("computerName", ri.ComputerName),
-                                        new XAttribute("outcome", ri.Outcome),
-                                        new XAttribute("timestamp", ri.Timestamp),
-                                        new XElement("Text", ri.Text)))))
-                             )
-                );
 
+            try
+            {
 
-            doc.Root.SetDefaultXmlNamespace("http://microsoft.com/schemas/VisualStudio/TeamTest/2010");
+                Console.WriteLine("Started serializeAndSaveTestRun");
+                XNamespace xmlns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+                XDocument doc =
+                    new XDocument(
+                      new XElement("TestRun",
+                            new XAttribute("id", testRun.Id),
+                            new XAttribute("name", testRun.Name),
+                            new XAttribute("runUser", testRun.RunUser),
+                            new XElement("Times",
+                                new XAttribute("creation", testRun.Times.Creation),
+                                new XAttribute("queuing", testRun.Times.Queuing),
+                                new XAttribute("start", testRun.Times.Start),
+                                new XAttribute("finish", testRun.Times.Finish)),
+                            new XElement("Results",
+                                testRun.Results.Select(
+                                    utr =>
+                                        new XElement("UnitTestResult",
+                                            new XAttribute("computerName", utr.ComputerName),
+                                            new XAttribute("duration", utr.Duration),
+                                            new XAttribute("endTime", utr.EndTime),
+                                            new XAttribute("executionId", utr.ExecutionId),
+                                            new XAttribute("outcome", utr.Outcome),
+                                            new XAttribute("startTime", utr.StartTime),
+                                            new XAttribute("testId", utr.TestId),
+                                            new XAttribute("testListId", utr.TestListId),
+                                            new XAttribute("testName", utr.TestName),
+                                            new XAttribute("testType", utr.TestType),
+                                            new XElement("Output",
+                                                 utr.Output.StdOut == null ? null : new XElement("StdOut", utr.Output.StdOut),
+                                                 utr.Output.ErrorInfo == null ? null :
+                                                 new XElement("ErrorInfo",
+                                                      utr.Output.ErrorInfo.Message == null ? null : new XElement("Message", utr.Output.ErrorInfo.Message),
+                                                      utr.Output.ErrorInfo.StackTrace == null ? null : new XElement("StackTrace", utr.Output.ErrorInfo.StackTrace)
+                                                      ))))),
+                          new XElement("TestDefinitions",
+                               testRun.TestDefinitions.Select(
+                                    td => new XElement("UnitTest",
+                                             new XAttribute("id", td.Id),
+                                             new XAttribute("name", td.Name),
+                                             new XAttribute("storage", td.Storage == null ? "" : td.Storage),
+                                             new XElement("Execution",
+                                                new XAttribute("id", td.Execution.Id)),
+                                             new XElement("TestMethod",
+                                                new XAttribute("adapterTypeName", td.TestMethod.AdapterTypeName == null ? "" : td.Storage),
+                                                new XAttribute("className", td.TestMethod.ClassName),
+                                                new XAttribute("codeBase", td.TestMethod.CodeBase),
+                                                new XAttribute("name", td.TestMethod.Name))))),
+                            new XElement("TestEntries",
+                                 testRun.TestEntries.Select(
+                                    te => new XElement("TestEntry",
+                                              new XAttribute("testId", te.TestId),
+                                              new XAttribute("executionId", te.ExecutionId),
+                                              new XAttribute("testListId", te.TestListId)))),
+                            new XElement("TestLists",
+                                testRun.TestLists.Distinct().Select(
+                                     tl => new XElement("TestList",
+                                         new XAttribute("name", tl.Name),
+                                         new XAttribute("id", tl.Id)))),
+                            new XElement("ResultSummary",
+                                new XAttribute("outcome", testRun.ResultSummary.Outcome),
+                                new XElement("Counters",
+                                    new XAttribute("aborted", testRun.ResultSummary.Counters.Aborted),
+                                    new XAttribute("completed", testRun.ResultSummary.Counters.Completed),
+                                    new XAttribute("disconnected", testRun.ResultSummary.Counters.Disconnected),
+                                    new XAttribute("executed", testRun.ResultSummary.Counters.Еxecuted),
+                                    new XAttribute("failed", testRun.ResultSummary.Counters.Failed),
+                                    new XAttribute("inconclusive", testRun.ResultSummary.Counters.Inconclusive),
+                                    new XAttribute("inProgress", testRun.ResultSummary.Counters.InProgress),
+                                    new XAttribute("notExecuted", testRun.ResultSummary.Counters.NotExecuted),
+                                    new XAttribute("notRunnable", testRun.ResultSummary.Counters.NotRunnable),
+                                    new XAttribute("passed", testRun.ResultSummary.Counters.Passed),
+                                    new XAttribute("passedButRunAborted", testRun.ResultSummary.Counters.PassedButRunAborted),
+                                    new XAttribute("pending", testRun.ResultSummary.Counters.Pending),
+                                    new XAttribute("timeout", testRun.ResultSummary.Counters.Timeout),
+                                    new XAttribute("total", testRun.ResultSummary.Counters.Total),
+                                    new XAttribute("warning", testRun.ResultSummary.Counters.Warning)),
+                                new XElement("RunInfos",
+                                    testRun.ResultSummary.RunInfos.Select(
+                                        ri => new XElement("RunInfo",
+                                            new XAttribute("computerName", ri.ComputerName),
+                                            new XAttribute("outcome", ri.Outcome),
+                                            new XAttribute("timestamp", ri.Timestamp),
+                                            new XElement("Text", ri.Text)))))
+                                 )
+                    );
 
-            if (File.Exists(targetPath))
-                File.Delete(targetPath);
+                Console.WriteLine("Finished parsing xml properties");
+                doc.Root.SetDefaultXmlNamespace("http://microsoft.com/schemas/VisualStudio/TeamTest/2010");
 
-            doc.Save(targetPath);
+                if (File.Exists(targetPath))
+                    File.Delete(targetPath);
 
-            var savedFileInfo = new FileInfo(targetPath);
+                doc.Save(targetPath);
 
-            return savedFileInfo.FullName;
+                var savedFileInfo = new FileInfo(targetPath);
+
+                return savedFileInfo.FullName;
+
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message + "/n" + ex.StackTrace);
+                throw ex;
+            }
         }
         #endregion
 
@@ -122,7 +135,7 @@ namespace TRX_Merger.Utilities
 
             using (Stream trxStream = new FileStream(trxPath, FileMode.Open, FileAccess.Read))
             {
-                XDocument doc = XDocument.Load(trxStream); 
+                XDocument doc = XDocument.Load(trxStream);
                 var run = doc.Root;
 
                 testRun.Id = run.Attribute("id").Value;
@@ -372,8 +385,8 @@ namespace TRX_Merger.Utilities
                 Queuing = xElement.Attribute("queuing").Value,
                 Start = xElement.Attribute("start").Value,
             };
-        } 
-        #endregion 
+        }
+        #endregion
 
     }
 }

--- a/TRX_Merger/packages.config
+++ b/TRX_Merger/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.Mvc" version="4.0.40804.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="4.0.0-beta6" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="RazorEngine" version="4.2.2-beta1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Protractor tests are now parseable, there is a try catch during the xml
parsing, if no report  path is specified IT SHOULD NOT EXPLODE