### PR TITLE
Merge in references to associated code coverage files

### DIFF
--- a/TRX_Merger/TRX_Merger.csproj
+++ b/TRX_Merger/TRX_Merger.csproj
@@ -60,9 +60,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TrxModel\Anchor.cs" />
+    <Compile Include="TrxModel\Collector.cs" />
     <Compile Include="TrxModel\Counters.cs" />
     <Compile Include="TrxModel\ErrorInfo.cs" />
     <Compile Include="TrxModel\Execution.cs" />
+    <Compile Include="TrxModel\ResultSummaryOutput.cs" />
     <Compile Include="TrxModel\ResultSummary.cs" />
     <Compile Include="TrxModel\RunInfo.cs" />
     <Compile Include="ReportModel\TestClassReport.cs" />
@@ -77,6 +80,7 @@
     <Compile Include="TrxModel\UnitTestResultOutput.cs" />
     <Compile Include="ReportModel\UnitTestResultReport.cs" />
     <Compile Include="ReportGenerator\TrxReportGenerator.cs" />
+    <Compile Include="TrxModel\UriAttachment.cs" />
     <Compile Include="Utilities\ExtensionMethods.cs" />
     <Compile Include="TestRunMerger.cs" />
     <Compile Include="Utilities\TRXSerializationUtils.cs" />

--- a/TRX_Merger/TestRunMerger.cs
+++ b/TRX_Merger/TestRunMerger.cs
@@ -46,8 +46,6 @@ namespace TRX_Merger
             DateTime endDate = DateTime.MinValue;
 
 
-
-
             List<UnitTestResult> allResults = new List<UnitTestResult>();
             List<UnitTest> allTestDefinitions = new List<UnitTest>();
             List<TestEntry> allTestEntries = new List<TestEntry>();
@@ -58,6 +56,8 @@ namespace TRX_Merger
             {
                 Counters = new Counters(),
                 RunInfos = new List<RunInfo>(),
+				Output = new ResultSummaryOutput(),
+				CollectorDataEntries = new List<Collector>()
             };
             bool resultSummaryPassed = true;
 
@@ -100,7 +100,8 @@ namespace TRX_Merger
                 resultSummary.Counters.Timeout += tr.ResultSummary.Counters.Timeout;
                 resultSummary.Counters.Total += tr.ResultSummary.Counters.Total;
                 resultSummary.Counters.Warning += tr.ResultSummary.Counters.Warning;
-
+				resultSummary.Output.StdOut += tr.ResultSummary.Output.StdOut + Environment.NewLine;
+				resultSummary.CollectorDataEntries = resultSummary.CollectorDataEntries.Concat(tr.ResultSummary.CollectorDataEntries).ToList();
             }
 
             resultSummary.Outcome = resultSummaryPassed ? "Passed" : "Failed";
@@ -124,7 +125,6 @@ namespace TRX_Merger
                 TestLists = allTestLists,
                 ResultSummary = resultSummary,
             };
-        } 
- 
+        }  
     }
 }

--- a/TRX_Merger/TrxModel/Anchor.cs
+++ b/TRX_Merger/TrxModel/Anchor.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TRX_Merger.TrxModel
+{
+	public class Anchor
+	{
+		public string href { get; set; }
+	}
+}

--- a/TRX_Merger/TrxModel/Collector.cs
+++ b/TRX_Merger/TrxModel/Collector.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TRX_Merger.TrxModel
+{
+	public class Collector
+	{
+		public string AgentName { get; set; }
+		public string Uri { get; set; }
+		public string CollectorDisplayName { get; set; }
+		public List<UriAttachment> UriAttachments { get; set; }
+	}
+}

--- a/TRX_Merger/TrxModel/ResultSummary.cs
+++ b/TRX_Merger/TrxModel/ResultSummary.cs
@@ -10,6 +10,8 @@ namespace TRX_Merger.TrxModel
     {
         public string Outcome { get; set; }
         public Counters Counters { get; set; }
+		public ResultSummaryOutput Output { get; set; }
         public List<RunInfo> RunInfos { get; set; }
+		public List<Collector> CollectorDataEntries { get; set; }
     }
 }

--- a/TRX_Merger/TrxModel/ResultSummaryOutput.cs
+++ b/TRX_Merger/TrxModel/ResultSummaryOutput.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TRX_Merger.TrxModel
+{
+	public class ResultSummaryOutput
+	{
+		public string StdOut { get; set; }
+	}
+}

--- a/TRX_Merger/TrxModel/UriAttachment.cs
+++ b/TRX_Merger/TrxModel/UriAttachment.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TRX_Merger.TrxModel
+{
+	public class UriAttachment
+	{
+		public Anchor A { get; set; }
+	}
+}


### PR DESCRIPTION
Added the ability to merge in the references to the local code coverage file(s) assocaited with the test run(s). This does not merge in the actual coverage results themselves. This information can now be used by an external tool to merge the code coverage file(s).